### PR TITLE
config: convert to a nicely formatted table

### DIFF
--- a/WordCount.sublime-settings
+++ b/WordCount.sublime-settings
@@ -1,77 +1,24 @@
-{
-	// Allows you to control if the estimated reading time is enabled.
-	// Reading time is only displayed when there is a time > 1s.
-	"enable_readtime": false,
-
-	// Display the number of words in file
-	"enable_count_words": true,
-
-	// Display the number of lines in file
-	"enable_count_lines": true,
-
-	// Display the number of characters in file
-	"enable_count_chars": true,
-
-	// Display the number of pages in file
-	"enable_count_pages": false,
-
-	// Sets the number of words per page used to calculate number of pages
-	"words_per_page": 360,
-
-	// The maximum characters a file to be computed can have
-	"file_size_limit": 4194304,
-
-	// Sets the WPM to calculate the Estimated Reading Time for the file.
-	"readtime_wpm": 200,
-
-	// Whether to skip whitespace for the character count.
-	"char_ignore_whitespace": true,
-
-	// Sets the page count mode to words per page
-	"page_count_mode_count_words": false,
-
-	// Display the count of words found on current line.
-	"enable_line_word_count": false,
-
-	// Display the count of characters found on current line.
-	"enable_line_char_count": false,
-
-	// An array of syntax names that WordCount should run on.
-	// Example: ["Plain text", "Markdown"]
-	// If the array is empty, like it is by default, WordCount will run on any syntax.
-	"whitelist_syntaxes": [],
-
-	// An array of syntax names that WordCount should not run on.
-	// Example: ["Plain text", "Markdown"]
-	// If the array is empty, like it is by default, WordCount will run on any syntax.
-	"blacklist_syntaxes": [],
-
-	// Word Regular expression. Defaults empty, an internal regular expression
-	// is used. If the portion of text matches this RegExp then the word is
-	// counted.
-	"word_regexp": "",
-
-	// Split portions of text to test later as words with a Regular expression.
-	// Defaults to String.split() with no arguments, means that content will
-	// trim() and empty values (all whitespaces) are not used. In case of
-	// containing some value different than empty, the return of "re.findall"
-	// will be used.
-	"word_split": "",
-
-	// Remove regex patterns by syntax. Split portions of text to test later as
-	// words with a Regular expression. Defaults to String.split() with no
-	// arguments, means that content will trim() and empty values (all
-	// whitespaces) are not used. In case of containing some value different
-	// than empty, the return of "re.findall" will be used.
-	//
-	// Please use lowercase for the syntax names in the following section:
-	"strip": {
-		// Example to ignore all tags, including comments, from HTML.
-		"html": [
-			"<[^>]*>",
-		],
-		"php": [
-			"<[^>]*>",
-		],
-	}
+{//Key                       	  Value  	     |Default|	Comment
+"enable_readtime"            	: false  	, // |false|  	Allows you to control if the estimated reading time is enabled. Reading time is only displayed when there is a time > 1s
+"enable_count_words"         	: true   	, // |true|   	Display the number of words      in file
+"enable_count_lines"         	: true   	, // |true|   	Display the number of lines      in file
+"enable_count_chars"         	: true   	, // |true|   	Display the number of characters in file
+"enable_count_pages"         	: false  	, // |false|  	Display the number of pages      in file
+"words_per_page"             	: 360    	, // |360|    	Sets the number of words per page used to calculate number of pages
+"file_size_limit"            	: 4194304	, // |4194304|	The maximum characters a file to be computed can have
+"readtime_wpm"               	: 200    	, // |200|    	Sets the WPM to calculate the Estimated Reading Time for the file
+"char_ignore_whitespace"     	: true   	, // |true|   	Whether to skip whitespace for the character count
+"page_count_mode_count_words"	: false  	, // |false|  	Sets the page count mode to words per page
+"enable_line_word_count"     	: false  	, // |false|  	Display the count of words found on current line
+"enable_line_char_count"     	: false  	, // |false|  	Display the count of characters found on current line
+"whitelist_syntaxes"         	: []     	, // |[]|     	An array of syntax names that WordCount should run on
+                             	         	  //          	Example: ["Plain text", "Markdown"]	If the array is empty, like it is by default, WordCount will run on any syntax
+"blacklist_syntaxes"         	: []     	, // |[]|     	An array of syntax names that WordCount should not run on Example: ["Plain text", "Markdown"] If the array is empty, like it is by default, WordCount will run on any syntax
+"word_regexp"                	: ""     	, // |""|     	Word Regular expression. Defaults empty, an internal regular expression is used. If the portion of text matches this RegExp then the word is counted
+"word_split"                 	: ""     	, // |""|     	Split portions of text to test later as words with a Regular expression. Defaults to String.split() with no arguments, means that content will trim() and empty values (all whitespaces) are not used. In case of containing some value different than empty, the return of "re.findall" will be used
+// Remove regex patterns by syntax. Split portions of text to test later as words with a Regular expression. Defaults to String.split() with no arguments, means that content will trim() and empty values (all whitespaces) are not used. In case of containing some value different than empty, the return of "re.findall" will be used
+"strip": { // Please use lowercase for the syntax names in the following section
+  "html": ["<[^>]*>",], // Example to ignore all tags, including comments, from HTML
+  "php" : ["<[^>]*>",],
+}
 }


### PR DESCRIPTION
When configuring your addon for the first time it's rather helpful to be able to have an easy overview of the various configuration.
I'd like to propose a reformatted table view (vertically aligned) of the default settings which
  - easily fits on one page
  - is easier to visually parse due to table alignment
  - allows the user to easily experiment by easily reverting to defaults (default values are included in the comments)

I think the new format is much readable...
<img width="1108" alt="cfg_new" src="https://user-images.githubusercontent.com/12956286/197378916-15a78a47-d7f2-41f0-a464-c974f7e18fd6.png">
...than the old one
<img width="1074" alt="cfg_old" src="https://user-images.githubusercontent.com/12956286/197378913-2834d5d0-36a2-4fb2-884c-d9fcf2e5aa79.png">
