### PR TITLE
feat: allow user customization of data labels

### DIFF
--- a/WordCount.py
+++ b/WordCount.py
@@ -120,6 +120,16 @@ class Preferences():
         Preferences.blacklist_syntaxes     = sublime_settings.get('blacklist_syntaxes', [])
         Preferences.strip                  = sublime_settings.get('strip', [])
 
+        Preferences.thousands_separator    = sublime_settings.get('thousands_separator'  , "." )
+
+        Preferences.label_line             = sublime_settings.get('label_line'        , " Lines"          )
+        Preferences.label_word             = sublime_settings.get('label_word'        , " Words"          )
+        Preferences.label_char             = sublime_settings.get('label_char'        , " Chars"          )
+        Preferences.label_word_in_line     = sublime_settings.get('label_word_in_line', " Words in lines" )
+        Preferences.label_char_in_line     = sublime_settings.get('label_char_in_line', " Chars in lines" )
+        Preferences.label_time             = sublime_settings.get('label_time'        , " reading time"   )
+        Preferences.label_page             = sublime_settings.get('label_page'        , "Page "           )
+
         Preferences.page_count_mode_count_words = sublime_settings.get('page_count_mode_count_words', True)
 
 
@@ -311,21 +321,22 @@ class WordCountView():
 def display(view, word_count, char_count, line_count, word_count_line, char_count_line):
     status  = []
     seconds = int( word_count % Preferences.readtime_wpm / ( Preferences.readtime_wpm / 60 ) )
+    k_sep   = Preferences.thousands_separator
 
     if line_count > 0:
-        status.append( "{:,} Lines".format( line_count ).replace( ',', '.' ) )
+        status.append( "{:,}{}".format( line_count     , Preferences.label_line         ).replace(',',k_sep) )
 
     if word_count > 0:
-        status.append( "{:,} Words".format( word_count ).replace( ',', '.' ) )
+        status.append( "{:,}{}".format( word_count     , Preferences.label_word         ).replace(',',k_sep) )
 
     if char_count > 0:
-        status.append( "{:,} Chars".format( char_count ).replace( ',', '.' ) )
+        status.append( "{:,}{}".format( char_count     , Preferences.label_char         ).replace(',',k_sep) )
 
     if word_count_line > 0:
-        status.append( "{:,} Words in line".format( word_count_line ).replace( ',', '.' ) )
+        status.append( "{:,}{}".format( word_count_line, Preferences.label_word_in_line ).replace(',',k_sep) )
 
     if char_count_line > 0:
-        status.append( "{:,} Chars in line".format( char_count_line ).replace( ',', '.' ) )
+        status.append( "{:,}{}".format( char_count_line, Preferences.label_char_in_line ).replace(',',k_sep) )
 
     if Preferences.enable_count_pages and word_count > 0:
 
@@ -343,11 +354,11 @@ def display(view, word_count, char_count, line_count, word_count_line, char_coun
             current_page = ceil((current_line / Preferences.words_per_page) / (rows / Preferences.words_per_page))
 
         if pages > 1:
-            status.append( "Page {:,}/{:,}".format( current_page, pages ).replace( ',', '.' ) )
+            status.append( "{}{:,}/{:,}".format( Preferences.label_page, current_page, pages ).replace( ',', k_sep ) )
 
     if Preferences.enable_readtime and seconds >= 1:
         minutes = int( word_count / Preferences.readtime_wpm )
-        status.append( "~{:,}m {:,}s reading time".format( minutes, seconds ).replace( ',', '.' ) )
+        status.append( "~{:,}m {:,}s{}".format( minutes, seconds, Preferences.label_time ).replace( ',', k_sep ) )
 
     status_text = ', '.join( status )
     view.set_status( 'WordCountStatus', status_text )

--- a/WordCount.sublime-settings
+++ b/WordCount.sublime-settings
@@ -1,77 +1,24 @@
-{
-	// Allows you to control if the estimated reading time is enabled.
-	// Reading time is only displayed when there is a time > 1s.
-	"enable_readtime": false,
-
-	// Display the number of words in file
-	"enable_count_words": true,
-
-	// Display the number of lines in file
-	"enable_count_lines": true,
-
-	// Display the number of characters in file
-	"enable_count_chars": true,
-
-	// Display the number of pages in file
-	"enable_count_pages": false,
-
-	// Sets the number of words per page used to calculate number of pages
-	"words_per_page": 360,
-
-	// The maximum characters a file to be computed can have
-	"file_size_limit": 4194304,
-
-	// Sets the WPM to calculate the Estimated Reading Time for the file.
-	"readtime_wpm": 200,
-
-	// Whether to skip whitespace for the character count.
-	"char_ignore_whitespace": true,
-
-	// Sets the page count mode to words per page
-	"page_count_mode_count_words": false,
-
-	// Display the count of words found on current line.
-	"enable_line_word_count": false,
-
-	// Display the count of characters found on current line.
-	"enable_line_char_count": false,
-
-	// An array of syntax names that WordCount should run on.
-	// Example: ["Plain text", "Markdown"]
-	// If the array is empty, like it is by default, WordCount will run on any syntax.
-	"whitelist_syntaxes": [],
-
-	// An array of syntax names that WordCount should not run on.
-	// Example: ["Plain text", "Markdown"]
-	// If the array is empty, like it is by default, WordCount will run on any syntax.
-	"blacklist_syntaxes": [],
-
-	// Word Regular expression. Defaults empty, an internal regular expression
-	// is used. If the portion of text matches this RegExp then the word is
-	// counted.
-	"word_regexp": "",
-
-	// Split portions of text to test later as words with a Regular expression.
-	// Defaults to String.split() with no arguments, means that content will
-	// trim() and empty values (all whitespaces) are not used. In case of
-	// containing some value different than empty, the return of "re.findall"
-	// will be used.
-	"word_split": "",
-
-	// Remove regex patterns by syntax. Split portions of text to test later as
-	// words with a Regular expression. Defaults to String.split() with no
-	// arguments, means that content will trim() and empty values (all
-	// whitespaces) are not used. In case of containing some value different
-	// than empty, the return of "re.findall" will be used.
-	//
-	// Please use lowercase for the syntax names in the following section:
-	"strip": {
-		// Example to ignore all tags, including comments, from HTML.
-		"html": [
-			"<[^>]*>",
-		],
-		"php": [
-			"<[^>]*>",
-		],
-	}
+{//Key                       	  Value  	     |Default|	Comment
+"enable_readtime"            	: false  	, // |false|  	Allows you to control if the estimated reading time is enabled. Reading time is only displayed when there is a time > 1s
+"enable_count_words"         	: true   	, // |true|   	Display the number of words      in file
+"enable_count_lines"         	: true   	, // |true|   	Display the number of lines      in file
+"enable_count_chars"         	: true   	, // |true|   	Display the number of characters in file
+"enable_count_pages"         	: false  	, // |false|  	Display the number of pages      in file
+"words_per_page"             	: 360    	, // |360|    	Sets the number of words per page used to calculate number of pages
+"file_size_limit"            	: 4194304	, // |4194304|	The maximum characters a file to be computed can have
+"readtime_wpm"               	: 200    	, // |200|    	Sets the WPM to calculate the Estimated Reading Time for the file
+"char_ignore_whitespace"     	: true   	, // |true|   	Whether to skip whitespace for the character count
+"page_count_mode_count_words"	: false  	, // |false|  	Sets the page count mode to words per page
+"enable_line_word_count"     	: false  	, // |false|  	Display the count of words found on current line
+"enable_line_char_count"     	: false  	, // |false|  	Display the count of characters found on current line
+"whitelist_syntaxes"         	: []     	, // |[]|     	An array of syntax names that WordCount should run on
+                             	         	  //          	Example: ["Plain text", "Markdown"]	If the array is empty, like it is by default, WordCount will run on any syntax
+"blacklist_syntaxes"         	: []     	, // |[]|     	An array of syntax names that WordCount should not run on Example: ["Plain text", "Markdown"] If the array is empty, like it is by default, WordCount will run on any syntax
+"word_regexp"                	: ""     	, // |""|     	Word Regular expression. Defaults empty, an internal regular expression is used. If the portion of text matches this RegExp then the word is counted
+"word_split"                 	: ""     	, // |""|     	Split portions of text to test later as words with a Regular expression. Defaults to String.split() with no arguments, means that content will trim() and empty values (all whitespaces) are not used. In case of containing some value different than empty, the return of "re.findall" will be used
+// Remove regex patterns by syntax. Split portions of text to test later as words with a Regular expression. Defaults to String.split() with no arguments, means that content will trim() and empty values (all whitespaces) are not used. In case of containing some value different than empty, the return of "re.findall" will be used
+"strip": { // Please use lowercase for the syntax names in the following section
+  "html": ["<[^>]*>",], // Example to ignore all tags, including comments, from HTML
+  "php" : ["<[^>]*>",],
+}
 }

--- a/WordCount.sublime-settings
+++ b/WordCount.sublime-settings
@@ -16,6 +16,16 @@
 "blacklist_syntaxes"         	: []     	, // |[]|     	An array of syntax names that WordCount should not run on Example: ["Plain text", "Markdown"] If the array is empty, like it is by default, WordCount will run on any syntax
 "word_regexp"                	: ""     	, // |""|     	Word Regular expression. Defaults empty, an internal regular expression is used. If the portion of text matches this RegExp then the word is counted
 "word_split"                 	: ""     	, // |""|     	Split portions of text to test later as words with a Regular expression. Defaults to String.split() with no arguments, means that content will trim() and empty values (all whitespaces) are not used. In case of containing some value different than empty, the return of "re.findall" will be used
+"thousands_separator"        	: "."    	, // |"."|    	Thousands separator's symbol
+
+"label_line"        	: " Lines"         	, // |" Lines"|         	Label for the number of lines
+"label_word"        	: " Words"         	, // |" Words"|         	Label for the number of words
+"label_char"        	: " Chars"         	, // |" Chars"|         	Label for the number of chars
+"label_word_in_line"	: " Words in lines"	, // |" Words in lines"|	Label for the number of words in lines
+"label_char_in_line"	: " Chars in lines"	, // |" Chars in lines"|	Label for the number of chars in lines
+"label_time"        	: " reading time"  	, // |" reading time"|  	Label for the reading time
+"label_page"        	: "Page "          	, // |"Page "|          	Label for the page number
+
 // Remove regex patterns by syntax. Split portions of text to test later as words with a Regular expression. Defaults to String.split() with no arguments, means that content will trim() and empty values (all whitespaces) are not used. In case of containing some value different than empty, the return of "re.findall" will be used
 "strip": { // Please use lowercase for the syntax names in the following section
   "html": ["<[^>]*>",], // Example to ignore all tags, including comments, from HTML


### PR DESCRIPTION
(this is based off the new config version from the other PR, but can rebase and return to the old ugly :) format if that's not accepted)

I don't like the very verbose default labels and replaced them with my much shorter custom versions
**1 Lines 2 Words 3 Chars 2 Words in lines 3 Chars in lines 1m 1s reading time Page 1/4**
**1━ 2w 3c 2w━ 3c━ 1m 1s⏳ 🗏1/4**

This PR enables any user to change the labels to whatever they like. I've left the defaults as is currently, though would suggest you look at the shorter beauty :) above and maybe also change the defaults

